### PR TITLE
LinearSelector improvement

### DIFF
--- a/cs-clrs/src/main/java/com/mmnaseri/cs/clrs/ch09/s3/LinearSelector.java
+++ b/cs-clrs/src/main/java/com/mmnaseri/cs/clrs/ch09/s3/LinearSelector.java
@@ -86,9 +86,9 @@ public class LinearSelector<E extends Comparable<E>> implements Selector<E> {
         if (pivot == order) {
             return pivot;
         } else if (order < pivot) {
-            return select(items, positions, from, pivot, order);
+            return select(items, positions, from, pivot-1, order);
         } else {
-            return select(items, positions, pivot, to, order);
+            return select(items, positions, pivot+1, to, order);
         }
     }
 

--- a/cs-clrs/src/main/java/com/mmnaseri/cs/clrs/ch09/s3/LinearSelector.java
+++ b/cs-clrs/src/main/java/com/mmnaseri/cs/clrs/ch09/s3/LinearSelector.java
@@ -10,6 +10,7 @@ import java.util.Comparator;
 
 /**
  * @author Mohammad Milad Naseri (mmnaseri@programmer.net)
+ * @author Ramin Farhanian (rf.tech@icloud.com)
  * @since 1.0 (7/12/15, 7:26 PM)
  */
 @Quality(Stage.TESTED)


### PR DESCRIPTION
Linear Selector should divide the problem into subproblems around the pivot element. If the order is not the pivot element, it should not include the pivot index in the subproblem.