### PR TITLE
FixedSizeQueue should recover from extreme dequeue operation + adding…

### DIFF
--- a/cs-clrs/src/main/java/com/mmnaseri/cs/clrs/ch10/s1/FixedSizeQueue.java
+++ b/cs-clrs/src/main/java/com/mmnaseri/cs/clrs/ch10/s1/FixedSizeQueue.java
@@ -50,7 +50,7 @@ public class FixedSizeQueue<E> {
         size --;
         final Object object = items[tail];
         items[tail] = null;
-        if (tail == items.length) {
+        if (tail == items.length - 1) {
             tail = -1;
         }
         //noinspection unchecked

--- a/cs-clrs/src/main/java/com/mmnaseri/cs/clrs/ch10/s1/FixedSizeQueue.java
+++ b/cs-clrs/src/main/java/com/mmnaseri/cs/clrs/ch10/s1/FixedSizeQueue.java
@@ -5,6 +5,7 @@ import com.mmnaseri.cs.qa.annotation.Stage;
 
 /**
  * @author Mohammad Milad Naseri (mmnaseri@programmer.net)
+ * @author Ramin Farhanian (rf.tech@icloud.com)
  * @since 1.0 (7/12/15, 9:44 PM)
  */
 @Quality(Stage.TESTED)

--- a/cs-clrs/src/test/java/com/mmnaseri/cs/clrs/ch10/s1/FixedSizeQueueTest.java
+++ b/cs-clrs/src/test/java/com/mmnaseri/cs/clrs/ch10/s1/FixedSizeQueueTest.java
@@ -9,6 +9,7 @@ import static org.testng.Assert.fail;
 
 /**
  * @author Mohammad Milad Naseri (mmnaseri@programmer.net)
+ * @author Ramin Farhanian (rf.tech@icloud.com)
  * @since 1.0 (7/12/15, 9:49 PM)
  */
 public class FixedSizeQueueTest {

--- a/cs-clrs/src/test/java/com/mmnaseri/cs/clrs/ch10/s1/FixedSizeQueueTest.java
+++ b/cs-clrs/src/test/java/com/mmnaseri/cs/clrs/ch10/s1/FixedSizeQueueTest.java
@@ -5,6 +5,7 @@ import org.testng.annotations.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.testng.Assert.fail;
 
 /**
  * @author Mohammad Milad Naseri (mmnaseri@programmer.net)
@@ -54,6 +55,21 @@ public class FixedSizeQueueTest {
             assertThat(queue.getSize(), is(items.length - i - 1));
         }
         assertThat(queue.isEmpty(), is(true));
+    }
+
+    @Test
+    public void testQueueCanRecoverAfterExtremeShrinkage() throws Exception {
+        final FixedSizeQueue<Integer> queue = new FixedSizeQueue<>(1);
+        assertThat(queue.isEmpty(), is(true));
+        try {
+            queue.dequeue();
+            fail("dequeue operation should not be possible when the queue is empty");
+        } catch (Exception e) {
+            final int value = 1;
+            queue.enqueue(value);
+            assertThat(queue.dequeue(),is(value));
+        }
+
     }
 
     @Test(dataProvider = "queueExpansionDataProvider")

--- a/cs-clrs/src/test/java/com/mmnaseri/cs/clrs/ch10/s1/FixedSizeQueueTest.java
+++ b/cs-clrs/src/test/java/com/mmnaseri/cs/clrs/ch10/s1/FixedSizeQueueTest.java
@@ -23,10 +23,10 @@ public class FixedSizeQueueTest {
     @DataProvider
     public Object[][] queueExpansionDataProvider() {
         return new Object[][]{
-            new Object[]{new Integer[]{8, 7, 6, 5, 4}},
-            new Object[]{new Integer[]{null, null, null, null}},
-            new Object[]{new Integer[]{1, 2, 3, 9, 7, 6}},
-            new Object[]{new Integer[]{Integer.MAX_VALUE, 0, 0, 0, 0, 0, 0, 0}},
+                new Object[]{new Integer[]{8, 7, 6, 5, 4}},
+                new Object[]{new Integer[]{null, null, null, null}},
+                new Object[]{new Integer[]{1, 2, 3, 9, 7, 6}},
+                new Object[]{new Integer[]{Integer.MAX_VALUE, 0, 0, 0, 0, 0, 0, 0}},
         };
     }
 
@@ -59,7 +59,11 @@ public class FixedSizeQueueTest {
 
     @Test
     public void testQueueCanRecoverAfterExtremeShrinkage() throws Exception {
-        final FixedSizeQueue<Integer> queue = new FixedSizeQueue<>(1);
+        final FixedSizeQueue<Integer> queue = new FixedSizeQueue<>(2);
+        queue.enqueue(5);
+        queue.enqueue(4);
+        queue.dequeue();
+        queue.dequeue();
         assertThat(queue.isEmpty(), is(true));
         try {
             queue.dequeue();
@@ -67,7 +71,7 @@ public class FixedSizeQueueTest {
         } catch (Exception e) {
             final int value = 1;
             queue.enqueue(value);
-            assertThat(queue.dequeue(),is(value));
+            assertThat(queue.dequeue(), is(value));
         }
 
     }


### PR DESCRIPTION
FixedSizeQueue should recover from extreme dequeue operation.  When queue is enqueued and dequeued several times (till it becomes empty), the tail index will lose track of the tail. It only happens if we dequeue after it becomes empty again. Changing the if logic will fix this problem. I started changing the code after the regression test failed. 